### PR TITLE
ndau/noms fork for non-Intel CPU, increased redis startup time

### DIFF
--- a/docker/bin/buildimage.sh
+++ b/docker/bin/buildimage.sh
@@ -42,7 +42,6 @@ echo "Building $NDAU_IMAGE_NAME..."
 if ! docker build \
        --build-arg COMMANDS_BRANCH="$COMMANDS_BRANCH" \
        --build-arg RUN_UNIT_TESTS="$RUN_UNIT_TESTS" \
-#       --platform "linux/amd64" \
        "$IMAGE_DIR" \
        --tag="$NDAU_IMAGE_NAME:$SHA" \
        --tag="$NDAU_IMAGE_NAME:latest"

--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -31,12 +31,12 @@ RUN apk add --no-cache bash git openssh make gcc libc-dev
 
 # The build_noms stage builds noms, caching results when posssible
 FROM go_build AS build_noms
-
-ENV ATTICLABS_DIR=$GOPATH/src/github.com/attic-labs
+# We're going to use our own noms.....
+ENV ATTICLABS_DIR=$GOPATH/src/github.com/ndau
 RUN mkdir -p "$ATTICLABS_DIR"
 # This copy exists to bust the cache if new commits exist
 COPY ./noms_sha /
-RUN git clone https://github.com/attic-labs/noms.git "$ATTICLABS_DIR"/noms
+RUN git clone https://github.com/ndau/noms.git "$ATTICLABS_DIR"/noms
 RUN go get -u "$ATTICLABS_DIR"/noms/...
 RUN cd /bin && go build "$ATTICLABS_DIR"/noms/cmd/noms
 

--- a/docker/image/docker-procmon-claimer.toml
+++ b/docker/image/docker-procmon-claimer.toml
@@ -95,6 +95,7 @@ output = ""
     stdout = "$LOG_DIR/redis.log"
     stderr = "$LOG_DIR/redis.log"
     # durations are done as time.Duration
+    maxstartup = "60s"
     maxshutdown = "5s"
 
     [[task.monitors]]

--- a/docker/image/docker-procmon-noclaimer.toml
+++ b/docker/image/docker-procmon-noclaimer.toml
@@ -90,6 +90,7 @@ output = ""
     stdout = "$LOG_DIR/redis.log"
     stderr = "$LOG_DIR/redis.log"
     # durations are done as time.Duration
+    maxstartup = "60s"
     maxshutdown = "5s"
 
     [[task.monitors]]


### PR DESCRIPTION
Now using a local fork of attic-labs/noms to support non-Intel CPUs. The only compatibility problem was in the hash performance tests, which used an Intel-specific blake2 library. This fork only removes the performance tests and makes no changes to the noms code.

In some situations redis is taking more than the default 5 seconds to start, occasionally more than 10. The startup timeout is now set to 60 seconds. That should be far more than needed, but there's no harm in a big value. If redis won't start the node can't run so we can just wait for it.