### PR TITLE
Node updates for `redis`, `tendermint`, and `procmon`

### DIFF
--- a/docker/image/Dockerfile
+++ b/docker/image/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --no-cache bash bind-tools ca-certificates curl openssl sed jq pytho
     update-ca-certificates 2>/dev/null
 
 # Use a specific version of redis.
-COPY --from=redis:5.0.14-alpine [ \
+# COPY --from=redis:5.0.14-alpine [ \
+COPY --from=redis:6.2.6-alpine [ \
     "usr/local/bin/redis-server", \
     "usr/local/bin/redis-sentinel", \
     "usr/local/bin/redis-cli", \

--- a/docker/image/docker-conf.sh
+++ b/docker/image/docker-conf.sh
@@ -195,6 +195,7 @@ sed -i -E \
     -e 's/^(timeout_prevote =) (.*)/\1 "3s"/' \
     -e 's/^(timeout_precommit =) (.*)/\1 "3s"/' \
     -e 's/^(timeout_commit =) (.*)/\1 "3s"/' \
+    -e 's/^(timeout_broadcast_tx_commit =) (.*)/\1 "30s"/'
     -e 's/^(moniker =) (.*)/\1 "'"$NODE_ID"'"/' \
     "$TM_DATA_DIR/config/config.toml"
 

--- a/docker/image/docker-procmon-claimer.toml
+++ b/docker/image/docker-procmon-claimer.toml
@@ -121,6 +121,7 @@ output = ""
     ]
     stdout = "$LOG_DIR/noms.log"
     stderr = "$LOG_DIR/noms.log"
+    maxstartup = "60s"
     maxshutdown = "5s"
 
     [[task.monitors]]
@@ -195,7 +196,7 @@ output = ""
     path = "$BIN_DIR/ndauapi"
     stdout = "$LOG_DIR/ndauapi.log"
     stderr = "$LOG_DIR/ndauapi.log"
-    maxstartup = "5s"
+    maxstartup = "60s"
     maxshutdown = "2s"
 
     [[task.monitors]]
@@ -223,7 +224,7 @@ output = ""
     ]
     stdout = "$LOG_DIR/claimer.log"
     stderr = "$LOG_DIR/claimer.log"
-    maxstartup = "5s"
+    maxstartup = "10s"
     maxshutdown = "2s"
 
     [[task.monitors]]

--- a/docker/image/docker-procmon-noclaimer.toml
+++ b/docker/image/docker-procmon-noclaimer.toml
@@ -116,6 +116,7 @@ output = ""
     ]
     stdout = "$LOG_DIR/noms.log"
     stderr = "$LOG_DIR/noms.log"
+    maxstartup = "60s"
     maxshutdown = "5s"
 
     [[task.monitors]]
@@ -190,7 +191,7 @@ output = ""
     path = "$BIN_DIR/ndauapi"
     stdout = "$LOG_DIR/ndauapi.log"
     stderr = "$LOG_DIR/ndauapi.log"
-    maxstartup = "5s"
+    maxstartup = "60s"
     maxshutdown = "2s"
 
     [[task.monitors]]

--- a/docker/image/docker-snapshot.sh
+++ b/docker/image/docker-snapshot.sh
@@ -38,7 +38,7 @@ mkdir -p "$SNAPSHOT_DATA_DIR/noms"
 "$BIN_DIR"/noms set new database "$SNAPSHOT_DATA_DIR/noms"::ndau
 "$BIN_DIR"/noms sync "$NOMS_DATA_DIR"::ndau "$SNAPSHOT_DATA_DIR/noms"::ndau
 # EJM delete all obsolete redis snapshot files before copying
-rm "$REDIS_DATA_DIR/temp-*"
+rm "$REDIS_DATA_DIR/temp*"
 cp -r "$REDIS_DATA_DIR" "$SNAPSHOT_DATA_DIR/redis"
 cp "$TM_DATA_DIR/config/genesis.json" "$TM_TEMP/config"
 cp -r "$TM_DATA_DIR/data/blockstore.db" "$TM_TEMP/data"

--- a/docker/image/docker-snapshot.sh
+++ b/docker/image/docker-snapshot.sh
@@ -37,6 +37,8 @@ mkdir -p "$TM_TEMP/data"
 mkdir -p "$SNAPSHOT_DATA_DIR/noms"
 "$BIN_DIR"/noms set new database "$SNAPSHOT_DATA_DIR/noms"::ndau
 "$BIN_DIR"/noms sync "$NOMS_DATA_DIR"::ndau "$SNAPSHOT_DATA_DIR/noms"::ndau
+# EJM delete all obsolete redis snapshot files before copying
+rm "$REDIS_DATA_DIR/temp-*"
 cp -r "$REDIS_DATA_DIR" "$SNAPSHOT_DATA_DIR/redis"
 cp "$TM_DATA_DIR/config/genesis.json" "$TM_TEMP/config"
 cp -r "$TM_DATA_DIR/data/blockstore.db" "$TM_TEMP/data"

--- a/docker/image/docker-snapshot.sh
+++ b/docker/image/docker-snapshot.sh
@@ -38,7 +38,7 @@ mkdir -p "$SNAPSHOT_DATA_DIR/noms"
 "$BIN_DIR"/noms set new database "$SNAPSHOT_DATA_DIR/noms"::ndau
 "$BIN_DIR"/noms sync "$NOMS_DATA_DIR"::ndau "$SNAPSHOT_DATA_DIR/noms"::ndau
 # EJM delete all obsolete redis snapshot files before copying
-rm "$REDIS_DATA_DIR/temp*"
+rm "$REDIS_DATA_DIR"/temp*
 cp -r "$REDIS_DATA_DIR" "$SNAPSHOT_DATA_DIR/redis"
 cp "$TM_DATA_DIR/config/genesis.json" "$TM_TEMP/config"
 cp -r "$TM_DATA_DIR/data/blockstore.db" "$TM_TEMP/data"


### PR DESCRIPTION
- Updates `redis` to version 6.2.6 and deletes `redis` temp files before making a snapshot.
- Increases `tendermint` timeout waiting for a tx to be committed to 30s to avoid spurious timeout errors.
- Increases `procmon` startup timeouts for several services to support slower systems and our larger databases. There's really no need to put a limit on most process startup times: if it doesn't start we can't proceed anyway.
- Minor update to `nsdh` tool to support the `Unstake` transaction