### PR TITLE
Sort node rankings, fix snapshot creation and downloads

### DIFF
--- a/docker/image/docker-env.sh
+++ b/docker/image/docker-env.sh
@@ -30,7 +30,7 @@ export SNAPSHOT_URL="https://s3.amazonaws.com"
 if [ -z "$SNAPSHOT_BUCKET" ]; then
     export SNAPSHOT_BUCKET="ndau-snapshots"
 else
-    export "$SNAPSHOT_BUCKET"
+    export SNAPSHOT_BUCKET="$SNAPSHOT_BUCKET"
 fi
 
 export GENERATED_GENESIS_SNAPSHOT="*"

--- a/docker/image/docker-env.sh
+++ b/docker/image/docker-env.sh
@@ -25,7 +25,12 @@ export SYSTEM_ACCOUNTS_TOML="$ROOT_DIR/system_accounts.toml"
 
 export NDAUHOME="$NODE_DATA_DIR"
 
-export SNAPSHOT_URL="https://s3.amazonaws.com"
+if [ -z "$SNAPSHOT_URL" ]; then
+    export SNAPSHOT_URL="https://s3.amazonaws.com"
+else
+    export SNAPSHOT_URL="$SNAPSHOT_URL"
+fi
+
 export SNAPSHOT_BUCKET="ndau-snapshots"
 export GENERATED_GENESIS_SNAPSHOT="*"
 export LOCAL_SNAPSHOT="$ROOT_DIR/snapshot-$NETWORK-0.tgz"

--- a/docker/image/docker-env.sh
+++ b/docker/image/docker-env.sh
@@ -25,13 +25,14 @@ export SYSTEM_ACCOUNTS_TOML="$ROOT_DIR/system_accounts.toml"
 
 export NDAUHOME="$NODE_DATA_DIR"
 
-if [ -z "$SNAPSHOT_URL" ]; then
-    export SNAPSHOT_URL="https://s3.amazonaws.com"
+export SNAPSHOT_URL="https://s3.amazonaws.com"
+
+if [ -z "$SNAPSHOT_BUCKET" ]; then
+    export SNAPSHOT_BUCKET="ndau-snapshots"
 else
-    export SNAPSHOT_URL="$SNAPSHOT_URL"
+    export "$SNAPSHOT_BUCKET"
 fi
 
-export SNAPSHOT_BUCKET="ndau-snapshots"
 export GENERATED_GENESIS_SNAPSHOT="*"
 export LOCAL_SNAPSHOT="$ROOT_DIR/snapshot-$NETWORK-0.tgz"
 

--- a/docker/image/docker-snapshot.sh
+++ b/docker/image/docker-snapshot.sh
@@ -32,11 +32,14 @@ mkdir -p "$TM_TEMP/config"
 mkdir -p "$TM_TEMP/data"
 
 # Copy all the data files we want into the temp dir.
+
 # JSG don't do a copy of noms, instead do a sync which compresses the DB
-# cp -r "$NOMS_DATA_DIR" "$SNAPSHOT_DATA_DIR/noms"
-mkdir -p "$SNAPSHOT_DATA_DIR/noms"
-"$BIN_DIR"/noms set new database "$SNAPSHOT_DATA_DIR/noms"::ndau
-"$BIN_DIR"/noms sync "$NOMS_DATA_DIR"::ndau "$SNAPSHOT_DATA_DIR/noms"::ndau
+cp -r "$NOMS_DATA_DIR" "$SNAPSHOT_DATA_DIR/noms"
+# noms is too big to shrink (!) so we're going back to the old way
+# mkdir -p "$SNAPSHOT_DATA_DIR/noms"
+# "$BIN_DIR"/noms set new database "$SNAPSHOT_DATA_DIR/noms"::ndau
+# "$BIN_DIR"/noms sync "$NOMS_DATA_DIR"::ndau "$SNAPSHOT_DATA_DIR/noms"::ndau
+
 # EJM delete all obsolete redis snapshot files before copying
 rm "$REDIS_DATA_DIR"/temp-*
 cp -r "$REDIS_DATA_DIR" "$SNAPSHOT_DATA_DIR/redis"


### PR DESCRIPTION
When calculating node rankings, sort by value then by alphabetical ndau address to prevent any possible non-determinism when creating the validator table in `EndBlock`.

Snapshots are becoming a problem due to their size. `docker-snapshot.sh` no longer tries to shrink the `noms` database, as `noms` crashes when trying to do so. This produces larger snapshots, which have become a problem for remote (from the AWS US East Zone where the snapshots are stored) nodes when trying to start or restart. Snapshots are mirrored to the `ndau-snapshots-ap` bucket in Singapore, but there was no way to tell a node to use them. If the environment variable $SNAPSHOT_BUCKET is provided when the container is created, that bucket will be used. Otherwise, the default `ndau-snapshots` bucket is used.